### PR TITLE
feat: add `@deno/shim-crypto` package

### DIFF
--- a/.vscode/project.code-workspace
+++ b/.vscode/project.code-workspace
@@ -5,6 +5,10 @@
 			"path": "../"
 		},
 		{
+			"name": "shim-crypto",
+			"path": "../packages/shim-crypto"
+		},
+		{
 			"name": "shim-deno",
 			"path": "../packages/shim-deno/src/"
 		},

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Deno shims for Node.js
 ## Packages
 
 - [@deno/shim-deno](packages/shim-deno) - Deno namespace shim.
+- [@deno/shim-crypto](packages/shim-crypto) - Shim for the `crypto` global.
 - [@deno/shim-prompts](packages/shim-prompts) - Shims for `alert`, `confirm` and
   `prompt`.
 - [@deno/shim-timers](packages/shim-timers) - Shims for `setTimeout` and

--- a/deno.json
+++ b/deno.json
@@ -4,6 +4,8 @@
       "exclude": [
         "node_modules",
         "dist",
+        "packages/shim-crypto/dist",
+        "packages/shim-crypto/node_modules",
         "packages/shim-deno/dist",
         "packages/shim-deno/node_modules",
         "packages/shim-deno/src/deno/stable/lib.deno.d.ts",
@@ -25,6 +27,8 @@
       "exclude": [
         "node_modules",
         "dist",
+        "packages/shim-crypto/dist",
+        "packages/shim-crypto/node_modules",
         "packages/shim-deno/dist",
         "packages/shim-deno/node_modules",
         "packages/shim-deno/src/deno/stable/lib.deno.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "node_deno_shimsworkspace",
   "workspaces": [
+    "packages/shim-crypto",
     "packages/shim-deno",
     "packages/shim-prompts",
     "packages/shim-timers"

--- a/packages/shim-crypto/LICENSE
+++ b/packages/shim-crypto/LICENSE
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright 2021 the Deno authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/shim-crypto/README.md
+++ b/packages/shim-crypto/README.md
@@ -1,0 +1,3 @@
+# @deno/shim-crypto
+
+Node shim for the web's `crypto` global.

--- a/packages/shim-crypto/package.json
+++ b/packages/shim-crypto/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@deno/shim-crypto",
+  "version": "0.1.0",
+  "description": "Node shim for the web's `crypto` global.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "prepare": "echo \"Prepared.\"",
+    "build": "tsc",
+    "test": "echo \"None at the moment\""
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/denoland/node_deno_shims.git"
+  },
+  "keywords": [
+    "shim",
+    "deno",
+    "node.js",
+    "crypto"
+  ],
+  "author": "The Deno authors",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/denoland/node_deno_shims/issues"
+  },
+  "homepage": "https://github.com/denoland/node_deno_shims#readme",
+  "devDependencies": {
+    "typescript": "^4.5.2",
+    "ts-node": "^10.4.0"
+  }
+}

--- a/packages/shim-crypto/src/index.ts
+++ b/packages/shim-crypto/src/index.ts
@@ -1,0 +1,1 @@
+export { webcrypto as crypto } from "crypto";

--- a/packages/shim-crypto/tsconfig.json
+++ b/packages/shim-crypto/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "CommonJS",
+    "strict": true,
+    "target": "ES2019",
+    "lib": ["ES2019"],
+    "declaration": true,
+    "outDir": "dist",
+    "stripInternal": true
+  },
+  "ts-node": {
+    "transpileOnly": true,
+    "files": true
+  },
+  "files": ["src/index.ts"]
+}


### PR DESCRIPTION
I know this seems kind of useless at the moment, but in the future this will also include polyfills for some of the missing webcrypto functionality that Node doesn't have.