### PR TITLE
fix(crypto): generate crypto types

### DIFF
--- a/packages/shim-crypto/package.json
+++ b/packages/shim-crypto/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@deno/shim-crypto",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Node shim for the web's `crypto` global.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "prepare": "echo \"Prepared.\"",
+    "prepare": "npm run generate-crypto-types",
     "build": "tsc",
+    "generate-crypto-types": "deno run --allow-read --allow-write ./scripts/generateCryptoTypes.ts",
     "test": "echo \"None at the moment\""
   },
   "files": [

--- a/packages/shim-crypto/scripts/generateCryptoTypes.ts
+++ b/packages/shim-crypto/scripts/generateCryptoTypes.ts
@@ -1,0 +1,88 @@
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
+import {
+  ClassDeclaration,
+  IndentationText,
+  InterfaceDeclaration,
+  Node,
+  Project,
+  StatementStructures,
+  Symbol,
+  TypeAliasDeclaration,
+  VariableStatement,
+} from "https://deno.land/x/ts_morph@13.0.2/mod.ts";
+
+/// Analyzes lib.dom.d.ts and extracts out all the types used by the `Crypto` interface.
+const project = new Project({
+  manipulationSettings: {
+    indentationText: IndentationText.TwoSpaces,
+  },
+});
+const domDtsFile = project.addSourceFileAtPath(
+  "../shim-deno/third_party/deno/cli/dts/lib.dom.d.ts",
+);
+const statements: (StatementStructures | string)[] = [];
+statements.push("// deno-lint-ignore-file");
+statements.push("// deno-fmt-ignore-file");
+statements.push(
+  "// DO NOT EDIT - This file is automatically maintained by `npm run generate-crypto-types`",
+);
+
+const visitedSymbols = new Set<Symbol>();
+const visitedNodes = new Set<Node>();
+const crypto = domDtsFile.getInterfaceOrThrow("Crypto");
+
+visitSymbol(crypto.getSymbolOrThrow());
+
+project.createSourceFile(
+  "./src/crypto.types.gen.ts",
+  { statements },
+  { overwrite: true },
+).saveSync();
+
+function visitSymbol(symbol: Symbol) {
+  if (visitedSymbols.has(symbol)) {
+    return;
+  }
+  visitedSymbols.add(symbol);
+
+  for (const declaration of symbol.getDeclarations()) {
+    if (
+      declaration.getSourceFile() !== domDtsFile ||
+      visitedNodes.has(declaration)
+    ) {
+      continue;
+    }
+
+    visitedNodes.add(declaration);
+
+    if (
+      Node.isInterfaceDeclaration(declaration) ||
+      Node.isTypeAliasDeclaration(declaration) ||
+      Node.isClassDeclaration(declaration)
+    ) {
+      writeDeclaration(declaration);
+    } else if (Node.isVariableDeclaration(declaration)) {
+      writeDeclaration(declaration.getVariableStatementOrThrow());
+    }
+
+    for (const descendant of declaration.getDescendants()) {
+      const symbol = descendant.getSymbol();
+      if (symbol != null) {
+        visitSymbol(symbol);
+      }
+    }
+  }
+
+  function writeDeclaration(
+    declaration:
+      | VariableStatement
+      | InterfaceDeclaration
+      | TypeAliasDeclaration
+      | ClassDeclaration,
+  ) {
+    const structure = declaration.getStructure();
+    structure.isExported = true;
+    statements.push(structure);
+  }
+}

--- a/packages/shim-crypto/scripts/generateCryptoTypes.ts
+++ b/packages/shim-crypto/scripts/generateCryptoTypes.ts
@@ -28,6 +28,8 @@ statements.push(
   "// DO NOT EDIT - This file is automatically maintained by `npm run generate-crypto-types`",
 );
 
+// ignore this bug in deno_lint (will be fixed in a future version)
+// deno-lint-ignore ban-types
 const visitedSymbols = new Set<Symbol>();
 const visitedNodes = new Set<Node>();
 const crypto = domDtsFile.getInterfaceOrThrow("Crypto");
@@ -40,6 +42,8 @@ project.createSourceFile(
   { overwrite: true },
 ).saveSync();
 
+// ignore this bug in deno_lint (will be fixed in a future version)
+// deno-lint-ignore ban-types
 function visitSymbol(symbol: Symbol) {
   if (visitedSymbols.has(symbol)) {
     return;

--- a/packages/shim-crypto/src/crypto.types.gen.ts
+++ b/packages/shim-crypto/src/crypto.types.gen.ts
@@ -1,0 +1,198 @@
+// deno-lint-ignore-file
+// deno-fmt-ignore-file
+// DO NOT EDIT - This file is automatically maintained by `npm run generate-crypto-types`
+
+/** Basic cryptography features available in the current context. It allows access to a cryptographically strong random number generator and to cryptographic primitives. */
+export interface Crypto {
+  /** Available only in secure contexts. */
+  readonly subtle: SubtleCrypto;
+  getRandomValues<T extends ArrayBufferView | null>(array: T): T;
+}
+
+/**
+ * This Web Crypto API interface provides a number of low-level cryptographic functions. It is accessed via the Crypto.subtle properties available in a window context (via Window.crypto).
+ * Available only in secure contexts.
+ */
+export interface SubtleCrypto {
+  decrypt(algorithm: AlgorithmIdentifier | RsaOaepParams | AesCtrParams | AesCbcParams | AesGcmParams, key: CryptoKey, data: BufferSource): Promise<any>;
+  deriveBits(algorithm: AlgorithmIdentifier | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params, baseKey: CryptoKey, length: number): Promise<ArrayBuffer>;
+  deriveKey(algorithm: AlgorithmIdentifier | EcdhKeyDeriveParams | HkdfParams | Pbkdf2Params, baseKey: CryptoKey, derivedKeyType: AlgorithmIdentifier | AesDerivedKeyParams | HmacImportParams | HkdfParams | Pbkdf2Params, extractable: boolean, keyUsages: KeyUsage[]): Promise<CryptoKey>;
+  digest(algorithm: AlgorithmIdentifier, data: BufferSource): Promise<ArrayBuffer>;
+  encrypt(algorithm: AlgorithmIdentifier | RsaOaepParams | AesCtrParams | AesCbcParams | AesGcmParams, key: CryptoKey, data: BufferSource): Promise<any>;
+  exportKey(format: "jwk", key: CryptoKey): Promise<JsonWebKey>;
+  exportKey(format: Exclude<KeyFormat, "jwk">, key: CryptoKey): Promise<ArrayBuffer>;
+  generateKey(algorithm: RsaHashedKeyGenParams | EcKeyGenParams, extractable: boolean, keyUsages: KeyUsage[]): Promise<CryptoKeyPair>;
+  generateKey(algorithm: AesKeyGenParams | HmacKeyGenParams | Pbkdf2Params, extractable: boolean, keyUsages: KeyUsage[]): Promise<CryptoKey>;
+  generateKey(algorithm: AlgorithmIdentifier, extractable: boolean, keyUsages: KeyUsage[]): Promise<CryptoKeyPair | CryptoKey>;
+  importKey(format: "jwk", keyData: JsonWebKey, algorithm: AlgorithmIdentifier | RsaHashedImportParams | EcKeyImportParams | HmacImportParams | AesKeyAlgorithm, extractable: boolean, keyUsages: KeyUsage[]): Promise<CryptoKey>;
+  importKey(format: Exclude<KeyFormat, "jwk">, keyData: BufferSource, algorithm: AlgorithmIdentifier | RsaHashedImportParams | EcKeyImportParams | HmacImportParams | AesKeyAlgorithm, extractable: boolean, keyUsages: KeyUsage[]): Promise<CryptoKey>;
+  sign(algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams, key: CryptoKey, data: BufferSource): Promise<ArrayBuffer>;
+  unwrapKey(format: KeyFormat, wrappedKey: BufferSource, unwrappingKey: CryptoKey, unwrapAlgorithm: AlgorithmIdentifier | RsaOaepParams | AesCtrParams | AesCbcParams | AesGcmParams, unwrappedKeyAlgorithm: AlgorithmIdentifier | RsaHashedImportParams | EcKeyImportParams | HmacImportParams | AesKeyAlgorithm, extractable: boolean, keyUsages: KeyUsage[]): Promise<CryptoKey>;
+  verify(algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams, key: CryptoKey, signature: BufferSource, data: BufferSource): Promise<boolean>;
+  wrapKey(format: KeyFormat, key: CryptoKey, wrappingKey: CryptoKey, wrapAlgorithm: AlgorithmIdentifier | RsaOaepParams | AesCtrParams | AesCbcParams | AesGcmParams): Promise<ArrayBuffer>;
+}
+
+export type AlgorithmIdentifier = Algorithm | string;
+
+export interface Algorithm {
+  name: string;
+}
+
+export interface RsaOaepParams extends Algorithm {
+  label?: BufferSource;
+}
+
+export type BufferSource = ArrayBufferView | ArrayBuffer;
+
+export interface AesCtrParams extends Algorithm {
+  counter: BufferSource;
+  length: number;
+}
+
+export interface AesCbcParams extends Algorithm {
+  iv: BufferSource;
+}
+
+export interface AesGcmParams extends Algorithm {
+  additionalData?: BufferSource;
+  iv: BufferSource;
+  tagLength?: number;
+}
+
+/**
+ * The CryptoKey dictionary of the Web Crypto API represents a cryptographic key.
+ * Available only in secure contexts.
+ */
+export interface CryptoKey {
+  readonly algorithm: KeyAlgorithm;
+  readonly extractable: boolean;
+  readonly type: KeyType;
+  readonly usages: KeyUsage[];
+}
+
+export interface KeyAlgorithm {
+  name: string;
+}
+
+export type KeyType = "private" | "public" | "secret";
+export type KeyUsage = "decrypt" | "deriveBits" | "deriveKey" | "encrypt" | "sign" | "unwrapKey" | "verify" | "wrapKey";
+export declare var CryptoKey: {
+      prototype: CryptoKey;
+      new(): CryptoKey;
+  };
+
+export interface EcdhKeyDeriveParams extends Algorithm {
+  public: CryptoKey;
+}
+
+export interface HkdfParams extends Algorithm {
+  hash: HashAlgorithmIdentifier;
+  info: BufferSource;
+  salt: BufferSource;
+}
+
+export type HashAlgorithmIdentifier = AlgorithmIdentifier;
+
+export interface Pbkdf2Params extends Algorithm {
+  hash: HashAlgorithmIdentifier;
+  iterations: number;
+  salt: BufferSource;
+}
+
+export interface AesDerivedKeyParams extends Algorithm {
+  length: number;
+}
+
+export interface HmacImportParams extends Algorithm {
+  hash: HashAlgorithmIdentifier;
+  length?: number;
+}
+
+export interface JsonWebKey {
+  alg?: string;
+  crv?: string;
+  d?: string;
+  dp?: string;
+  dq?: string;
+  e?: string;
+  ext?: boolean;
+  k?: string;
+  key_ops?: string[];
+  kty?: string;
+  n?: string;
+  oth?: RsaOtherPrimesInfo[];
+  p?: string;
+  q?: string;
+  qi?: string;
+  use?: string;
+  x?: string;
+  y?: string;
+}
+
+export interface RsaOtherPrimesInfo {
+  d?: string;
+  r?: string;
+  t?: string;
+}
+
+export type KeyFormat = "jwk" | "pkcs8" | "raw" | "spki";
+
+export interface RsaHashedKeyGenParams extends RsaKeyGenParams {
+  hash: HashAlgorithmIdentifier;
+}
+
+export interface RsaKeyGenParams extends Algorithm {
+  modulusLength: number;
+  publicExponent: BigInteger;
+}
+
+export type BigInteger = Uint8Array;
+
+export interface EcKeyGenParams extends Algorithm {
+  namedCurve: NamedCurve;
+}
+
+export type NamedCurve = string;
+
+export interface CryptoKeyPair {
+  privateKey?: CryptoKey;
+  publicKey?: CryptoKey;
+}
+
+export interface AesKeyGenParams extends Algorithm {
+  length: number;
+}
+
+export interface HmacKeyGenParams extends Algorithm {
+  hash: HashAlgorithmIdentifier;
+  length?: number;
+}
+
+export interface RsaHashedImportParams extends Algorithm {
+  hash: HashAlgorithmIdentifier;
+}
+
+export interface EcKeyImportParams extends Algorithm {
+  namedCurve: NamedCurve;
+}
+
+export interface AesKeyAlgorithm extends KeyAlgorithm {
+  length: number;
+}
+
+export interface RsaPssParams extends Algorithm {
+  saltLength: number;
+}
+
+export interface EcdsaParams extends Algorithm {
+  hash: HashAlgorithmIdentifier;
+}
+
+export declare var SubtleCrypto: {
+      prototype: SubtleCrypto;
+      new(): SubtleCrypto;
+  };
+export declare var Crypto: {
+      prototype: Crypto;
+      new(): Crypto;
+  };

--- a/packages/shim-crypto/src/index.ts
+++ b/packages/shim-crypto/src/index.ts
@@ -1,1 +1,12 @@
-export { webcrypto as crypto } from "crypto";
+// Copyright 2018-2022 the Deno authors. All rights reserved. MIT license.
+
+import { webcrypto } from "crypto";
+import type { Crypto } from "./crypto.types.gen.js";
+
+// At the time of writing this, DefinitelyTyped is missing types for webcrypto for Node.
+// The workaround is to just use the types from lib.dom.ts and hope people are
+// running unit tests in order to find any issues.
+const crypto = webcrypto as unknown as Crypto;
+
+export { crypto };
+export * from "./crypto.types.gen.js";


### PR DESCRIPTION
This PR fixes the web crypto types by extracting out the crypto types from lib.dom.d.ts and bundling them in the shim.

This is necessary because DefinitelyTyped does not provide types for web crypto at the current time. It is true that not all node web crypto functions will be supported and doing this might hide that during type checking... it will be up to users of the shim to test their usages to ensure they work.