### PR TITLE
Shim `EventTarget` to support Node 14

### DIFF
--- a/packages/shim-deno/src/deno/stable/classes/PermissionStatus.ts
+++ b/packages/shim-deno/src/deno/stable/classes/PermissionStatus.ts
@@ -3,6 +3,8 @@
 // The listeners don't actually matter because the state of these permissions
 // is constant and mocked as Node.js has all doors open.
 
+(globalThis as any).EventTarget ??= require("events").EventTarget ?? null;
+
 export class PermissionStatus extends EventTarget
   implements Deno.PermissionStatus {
   onchange: ((this: PermissionStatus, ev: Event) => any) | null = null;


### PR DESCRIPTION
Trying to make tests pass on Node 14 (#77) proved difficult. This non-breaking change makes them at least run.