### PR TITLE
chore: ensure that `shim-deno` runs (not necessarily correctly) on Node 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,8 @@ jobs:
     - run: npm ci  --ignore-scripts
     - run: npm run --silent build --workspaces
     - run: npm run --silent test --workspaces
-    - run: cd packages/shim-deno && tools/missing.ts || echo "Some items are missing"
+    - name: Try running on Node 14
+      run: cd packages/shim-deno && npx node@14 dist/index.js
       if: matrix.os == 'ubuntu-latest'
     - run: cd packages/shim-deno && tools/untested.sh
       if: matrix.os == 'ubuntu-latest'


### PR DESCRIPTION
Closes #77. Closes #15.

The step I replaced could never fail.

`npm publish` step seems unused.

Since there isn't a pre-commit hook anymore, https://github.com/denoland/node_deno_shims/blob/aa22b201add21509bea5effe7fd59128b4ade32b/packages/shim-deno/tools/missing.ts#L36-L42 slows down `tools/missing.ts` for no benefit.