### PR TITLE
fix(shim-deno/create): Fix wrong OpenOptions on Deno.create

### DIFF
--- a/packages/shim-deno/src/deno/internal/fs_flags.ts
+++ b/packages/shim-deno/src/deno/internal/fs_flags.ts
@@ -36,7 +36,7 @@ export function getCreationFlag(opts: Opts<CreationModes>) {
   if (!opts.write && !opts.append) {
     if (opts.truncate || opts.create || opts.createNew) {
       throw new errors.BadResource(
-        "EINVAL: One of 'truncate', 'create', 'createNew' is required when 'write' and 'append' are false.",
+        "EINVAL: One of 'write', 'append' is required to 'truncate', 'create' or 'createNew' file.",
       );
     }
   }

--- a/packages/shim-deno/src/deno/stable/functions/create.ts
+++ b/packages/shim-deno/src/deno/stable/functions/create.ts
@@ -3,5 +3,5 @@
 import { open } from "./open.js";
 
 export const create: typeof Deno.create = async function create(path) {
-  return await open(path, { create: true, truncate: true });
+  return await open(path, { write: true, create: true, truncate: true });
 };


### PR DESCRIPTION
Hi. I'm working on using dnt on our project, [pbkit](https://github.com/pbkit/pbkit)
I noticed that the shim of Deno.create always throw an exception because the flag option on `create` doesn't have `write` option.
So I fixed it by adding `write` option and the wrong error message too.

Thanks for your contribution on dnt and this project!