### PR TITLE
Wrap with mapError to catch Deno.errors.NotFound correctly

### DIFF
--- a/packages/shim-deno/src/deno/stable/functions/lstat.ts
+++ b/packages/shim-deno/src/deno/stable/functions/lstat.ts
@@ -2,6 +2,12 @@
 
 import * as fs from "fs/promises";
 import { denoifyFileInfo } from "./stat.js";
+import mapError from "../../internal/errorMap.js";
 
-export const lstat: typeof Deno.lstat = async (path) =>
-  denoifyFileInfo(await fs.lstat(path));
+export const lstat: typeof Deno.lstat = async (path) => {
+  try {
+    return denoifyFileInfo(await fs.lstat(path));
+  } catch (e) {
+    throw mapError(e);
+  }
+};

--- a/packages/shim-deno/src/deno/stable/functions/stat.ts
+++ b/packages/shim-deno/src/deno/stable/functions/stat.ts
@@ -2,6 +2,7 @@
 
 import { stat as nodeStat } from "fs/promises";
 import type { Stats } from "fs";
+import mapError from "../../internal/errorMap.js";
 
 export function denoifyFileInfo(s: Stats): Deno.FileInfo {
   return {
@@ -24,5 +25,10 @@ export function denoifyFileInfo(s: Stats): Deno.FileInfo {
   };
 }
 
-export const stat: typeof Deno.stat = async (path) =>
-  denoifyFileInfo(await nodeStat(path));
+export const stat: typeof Deno.stat = async (path) => {
+  try {
+    return denoifyFileInfo(await nodeStat(path));
+  } catch (e) {
+    throw mapError(e);
+  }
+};


### PR DESCRIPTION
I wrapped `lstat`, `stat` with `mapError` to convert node error to deno one instead of using `[Symbol.hasInstance]
`
resolves #94 