### PR TITLE
fix(shim-deno/std): Fix std not to use FsFile

### DIFF
--- a/packages/shim-deno/src/deno/stable/variables/std.ts
+++ b/packages/shim-deno/src/deno/stable/variables/std.ts
@@ -15,17 +15,21 @@ function defer<T>(): Deferred<T> {
 export const stdin: typeof Deno.stdin = {
   rid: 0,
   read(p) {
-    const result = defer<number | null>();
+    const deferred = defer<number | null>();
     p.fill(0);
     process.stdin.resume();
     process.stdin.once("readable", () => {
       const data = process.stdin.read(p.length) ?? process.stdin.read();
-      p.set(data);
-      result.resolve(data.length > 0 ? data.length : null);
+      if (data) {
+        p.set(data);
+        deferred.resolve(data.length > 0 ? data.length : null);
+      } else {
+        deferred.resolve(null);
+      }
     });
-    return result.then((res) => {
+    return deferred.then((result) => {
       process.stdin.pause();
-      return res;
+      return result;
     });
   },
   get readable(): ReadableStream<Uint8Array> {

--- a/packages/shim-deno/src/deno/stable/variables/std.ts
+++ b/packages/shim-deno/src/deno/stable/variables/std.ts
@@ -2,7 +2,7 @@
 
 function chain<T extends (...args: any[]) => Promise<any>>(
   fn: T,
-  cleanup?: () => void
+  cleanup?: () => void,
 ): T {
   let prev: Promise<any> | undefined;
   return function _fn(...args) {
@@ -40,7 +40,7 @@ export const stdin: typeof Deno.stdin = {
         }
       });
     },
-    () => process.stdin.pause()
+    () => process.stdin.pause(),
   ),
   get readable(): ReadableStream<Uint8Array> {
     throw new Error("Not implemented.");

--- a/packages/shim-deno/src/deno/stable/variables/std.ts
+++ b/packages/shim-deno/src/deno/stable/variables/std.ts
@@ -1,7 +1,87 @@
 ///<reference path="../lib.deno.d.ts" />
 
-import { File } from "../classes/FsFile.js";
+interface Deferred<T> extends Promise<T> {
+  resolve(value: T): void;
+  reject(reason?: any): void;
+}
+function defer<T>(): Deferred<T> {
+  const transit: any = {};
+  const result = new Promise((resolve, reject) =>
+    Object.assign(transit, { resolve, reject })
+  );
+  return Object.assign(result, transit);
+}
 
-export const stdin: typeof Deno.stdin = new File(0);
-export const stdout: typeof Deno.stdout = new File(1);
-export const stderr: typeof Deno.stderr = new File(2);
+export const stdin: typeof Deno.stdin = {
+  rid: 0,
+  read(p) {
+    const result = defer<number | null>();
+    p.fill(0);
+    process.stdin.resume();
+    process.stdin.once("readable", () => {
+      const data = process.stdin.read(p.length) ?? process.stdin.read();
+      p.set(data);
+      result.resolve(data.length > 0 ? data.length : null);
+    });
+    return result.then((res) => {
+      process.stdin.pause();
+      return res;
+    });
+  },
+  get readable(): ReadableStream<Uint8Array> {
+    throw new Error("Not implemented.");
+  },
+  readSync() {
+    // Node.js doesn't support readSync for stdin
+    throw new Error("Not implemented.");
+  },
+  close() {
+    process.stdin.destroy();
+  },
+};
+export const stdout: typeof Deno.stdout = {
+  rid: 1,
+  write(p) {
+    const deferred = defer<number>();
+    const result = process.stdout.write(p);
+    if (!result) {
+      process.stdout.once("drain", () => deferred.resolve(p.length));
+    } else {
+      deferred.resolve(p.length);
+    }
+    return deferred;
+  },
+  get writable(): WritableStream<Uint8Array> {
+    throw new Error("Not implemented.");
+  },
+  writeSync() {
+    // Node.js doesn't support writeSync for stdout
+    throw new Error("Not implemented");
+  },
+  close() {
+    process.stdout.destroy();
+  },
+};
+export const stderr: typeof Deno.stderr = {
+  rid: 2,
+  write(p) {
+    const deferred = defer<number>();
+    const result = process.stderr.write(p);
+    if (!result) {
+      process.stderr.once("drain", () => deferred.resolve(p.length));
+    } else {
+      deferred.resolve(p.length);
+    }
+    return deferred;
+  },
+  get writable(): WritableStream<Uint8Array> {
+    throw new Error("Not implemented.");
+  },
+  writeSync() {
+    // Node.js doesn't support readSync for stderr
+    throw new Error("Not implemented");
+  },
+  close() {
+    process.stderr.destroy();
+  },
+};

--- a/packages/shim-deno/src/deno/stable/variables/std.ts
+++ b/packages/shim-deno/src/deno/stable/variables/std.ts
@@ -78,7 +78,7 @@ export const stderr: typeof Deno.stderr = {
     throw new Error("Not implemented.");
   },
   writeSync() {
-    // Node.js doesn't support readSync for stderr
+    // Node.js doesn't support writeSync for stderr
     throw new Error("Not implemented");
   },
   close() {


### PR DESCRIPTION
If node's "process" module is imported, accessing stdin by `fs.read` throws `EAGAIN` error: resource temporarily unavailable.
So I re-implemented std interface using `process.stdin`, `process.stdout`, `process.stderr`.

resolves #97 